### PR TITLE
Top Users Chart v2

### DIFF
--- a/src/_App/About.js
+++ b/src/_App/About.js
@@ -35,8 +35,8 @@ export default function About() {
                     <ol type="I">
                         <li>Tweet Collection
                             <ol>
-                                <li><a href="/collection-topics">Collection Topics</a></li>
                                 <li><a href="/collection-timeline">Collection Timeline</a></li>
+                                <li><a href="/collection-topics">Collection Topics</a></li>
                                 <li><a href="/collection-results">Collection Results</a></li>
                             </ol>
                         </li>

--- a/src/_App/OpinionAnalysis/TopUsers/Section.js
+++ b/src/_App/OpinionAnalysis/TopUsers/Section.js
@@ -20,9 +20,7 @@ export default function TopUserOpinion() {
                     </Card.Text>
 
                     <Card.Text>
-                        The chart below shows mean impeachment opinion scores for the users in our dataset who have the most followers.
-                        {" "}NOTE: bar size represents the number of followers, while color represents the opinion score.
-                        {" "}NOTE: follower counts are based on users in our dataset only.
+                        The chart below shows mean impeachment opinion scores for the users in our dataset who have the most followers in our dataset.
                     </Card.Text>
                 </Card.Body>
             </Card>

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.css
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.css
@@ -1,39 +1,38 @@
 
-
 .rc-slider-mark-text {
     width: 150px;
 }
 
 
+
 .chart-title-p {
     display:none;
 }
-
 .chart-title-h4 {
     display:block;
 }
 
+.below-chart {
+    margin-top: -100px
+}
 
 @media (min-width: 768px) and (max-width: 768px) {
-
-  .chart-title-p {
+    .chart-title-p {
         display:none;
     }
-
     .chart-title-h4 {
         display:block;
     }
-
 }
 
 @media (min-width: 320px) and (max-width: 768px) {
-
     .chart-title-p {
         display:block;
     }
-
     .chart-title-h4 {
         display:none;
     }
-
+    .below-chart {
+        margin-top: -60px
+    }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -63,28 +63,29 @@ export default class MyBarChart extends Component {
             userCategories: ALL_CATEGORY_NAMES,
             opinionModel: "lr",
         }
-        this.handleCategorySelect = this.handleCategorySelect.bind(this)
-        this.handleMetricSelect = this.handleMetricSelect.bind(this)
-
         this.handleTweetMinChange = this.handleTweetMinChange.bind(this)
         this.handleOpinionRangeChange = this.handleOpinionRangeChange.bind(this)
         this.handleCategoryCheck = this.handleCategoryCheck.bind(this)
         this.handleModelSelect = this.handleModelSelect.bind(this)
+
+        this.handleCategorySelect = this.handleCategorySelect.bind(this)
+        this.handleMetricSelect = this.handleMetricSelect.bind(this)
+
     }
 
     render() {
-        var sortMetric = this.state.sortMetric
-        var sortOrder = this.state.sortOrder
-
-
-
         var tweetMin = this.state.tweetMin
         var opinionRange = this.state.opinionRange
         var userCategories = this.state.userCategories
         var opinionModel = this.state.opinionModel
         var opinionMetric = `avg_score_${opinionModel}`
-
         var handleCategoryCheck = this.handleCategoryCheck
+
+        var sortMetric = this.state.sortMetric
+        if(sortMetric === "opinion_score"){
+            sortMetric = opinionMetric
+        }
+        var sortOrder = this.state.sortOrder
 
         // FILTER AND SORT USERS
 

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -75,6 +75,7 @@ export default class MyBarChart extends Component {
 
         this.handleCategorySelect = this.handleCategorySelect.bind(this)
         this.handleMetricSelect = this.handleMetricSelect.bind(this)
+        this.barLabel = this.barLabel.bind(this)
 
     }
 
@@ -86,6 +87,7 @@ export default class MyBarChart extends Component {
         var opinionModel = this.state.opinionModel
         var opinionMetric = `avg_score_${opinionModel}`
         var handleCategoryCheck = this.handleCategoryCheck
+        var barLabel = this.barLabel
 
         var sortMetric = this.state.sortMetric
         if(sortMetric === "opinion_score"){
@@ -173,7 +175,7 @@ export default class MyBarChart extends Component {
                         barRatio={0.87}
                         //alignment="middle"
 
-                        labels={({ datum }) => datum["scorePct"]}
+                        labels={({ datum }) => barLabel(datum)}
                         //labelComponent={<VictoryLabel dx={-30}/>}
                         style={{
                             //parent: { border: "1px solid #ccc" }
@@ -223,10 +225,10 @@ export default class MyBarChart extends Component {
                         <Col xs="6">
                             <Form.Label>Sort By:</Form.Label>
                             <Form.Control as="select" size="lg" custom onChange={this.handleMetricSelect}>
-                                <option value="most-followed">Most Followed</option>
-                                <option value="most-active">Most Active</option>
-                                <option value="most-pro-trump">Most Pro-Trump</option>
-                                <option value="most-pro-impeachment">Most Pro-Impeachment</option>
+                                <option value="most-followed">Follower Count</option>
+                                <option value="most-active">Tweet Count</option>
+                                <option value="most-pro-trump">Pro-Trump Score</option>
+                                <option value="most-pro-impeachment">Pro-Impeachment Score</option>
                                 {/* <option value="most-neutral">Most Neutral</option> */}
                             </Form.Control>
                         </Col>
@@ -404,4 +406,13 @@ export default class MyBarChart extends Component {
         })
     }
 
+    barLabel(datum){
+        var metric = this.state.sortMetric
+        if (metric == "opinion_score"){
+            return datum["scorePct"]
+        } else {
+            return formatBigNumber(datum[metric])
+        }
+
+    }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -11,6 +11,7 @@ import {scaleSequential, interpolateRdBu} from 'd3'
 import RangeSlider from 'react-bootstrap-range-slider'
 //import { Range } from 'rc-slider'
 import Slider from 'rc-slider'
+import ReactGA from 'react-ga'
 
 import './VBarChart.css'
 
@@ -327,14 +328,39 @@ export default class MyBarChart extends Component {
     }
 
     handleTweetMinChange(changeEvent){
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Change Tweet Min",
+            value: changeEvent.target.value
+        })
         this.setState({tweetMin: changeEvent.target.value})
     }
 
     handleFollowerMinChange(changeEvent){
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Change Follower Min",
+            value: changeEvent.target.value
+        })
         this.setState({followerMin: changeEvent.target.value})
     }
 
     handleOpinionRangeChange(newRange){
+        //ReactGA.event({
+        //    category: "Top Users Chart Interaction",
+        //    action: "Change Opinion Min",
+        //    value: newRange[0]
+        //})
+        //ReactGA.event({
+        //    category: "Top Users Chart Interaction",
+        //    action: "Change Opinion Max",
+        //    value: newRange[1]
+        //})
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Change Opinion Range",
+            label: newRange.join(", ")
+        })
         console.log("CHANGE OPINION RANGE", newRange)
         this.setState({opinionRange: newRange})
     }
@@ -352,24 +378,44 @@ export default class MyBarChart extends Component {
         }
 
         console.log("CATEGORIES:", userCategories)
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Change Opinion Min",
+            label: userCategories.join(", ")
+        })
         this.setState({userCategories: userCategories})
     }
 
     handleModelSelect(changeEvent){
         var model = changeEvent.target.value
         console.log("SELECT MODEL:", model)
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Select Opinion Model",
+            label: model
+        })
         this.setState({"opinionModel": model})
     }
 
     handleCategorySelect(changeEvent){
         var val = changeEvent.target.value
         console.log("FILTER BY CATEGORY:", val)
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Select User Category",
+            label: val
+        })
         this.setState({userCategories: FILTER_CATEGORIES[val]})
     }
 
     handleMetricSelect(changeEvent){
         var val = changeEvent.target.value
         console.log("SORT BY METRIC:", val)
+        ReactGA.event({
+            category: "Top Users Chart Interaction",
+            action: "Select Sort Metric",
+            label: val
+        })
         this.setState({
             sortMetric: SORT_METRICS[val]["metric"],
             sortOrder: SORT_METRICS[val]["order"],

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -43,7 +43,7 @@ const FILTER_CATEGORIES = {
 
 }
 const SORT_METRICS = {
-    "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count"},
+    "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count (in our dataset)"},
     "most-active": {"metric": "status_count", "order": "desc", "label": "Tweet Count"},
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
@@ -60,10 +60,9 @@ export default class MyBarChart extends Component {
         super(props)
         this.state = { // TODO: get URL params from router, so we can make custom charts and link people to them, like ?opinionMin=40&opinionMax=60&tweetMin=10
 
-            //sortMetric: "most-followed",
-            sortMetric: "follower_count", // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
-            sortOrder: "desc", // "desc", "asc"
-            sortLabel: "Follower Count", // "desc", "asc"
+            sortMetric: SORT_METRICS["most-followed"]["metric"], // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
+            sortOrder:  SORT_METRICS["most-followed"]["order"], // "desc", "asc"
+            sortLabel:  SORT_METRICS["most-followed"]["label"], // "desc", "asc"
 
             tweetMin: 5,
             followerMin: 10000,

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -44,7 +44,6 @@ const SORT_METRICS = {
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc"},
 }
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
-var SLICE = {"asc": BAR_COUNT, "desc": -BAR_COUNT} // negative number takes last X users (which is actually the top X users)
 
 function formatBigNumber(num) {
     // h/t: https://stackoverflow.com/a/9461657
@@ -55,8 +54,8 @@ export default class MyBarChart extends Component {
     constructor(props) {
         super(props)
         this.state = { // TODO: get URL params from router, so we can make custom charts and link people to them, like ?opinionMin=40&opinionMax=60&tweetMin=10
-            sortMetric: "follower_count", // can be "follower_count", "status_count", "opinion_metric" (needs differentiation)
-            sortOrder: "desc",
+            sortMetric: "opinion_score", // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
+            sortOrder: "asc", // "desc", "asc"
 
             tweetMin: 5,
             opinionRange: [0, 100],
@@ -103,9 +102,14 @@ export default class MyBarChart extends Component {
                 return user
             })
             .sort(function(a, b){
-                return a[sortMetric] - b[sortMetric] // chart wants this order
+                // chart wants this order
+                if(sortOrder === "desc"){
+                    return a[sortMetric] - b[sortMetric]
+                } else if (sortOrder === "asc"){
+                    return b[sortMetric] - a[sortMetric]
+                }
             }) // sort before slice
-            .slice(SLICE[sortOrder])
+            .slice(-BAR_COUNT) // negative number takes last X users (which is actually the top X users)
 
         // CHART CONTROLS
 

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -3,7 +3,7 @@ import Form from 'react-bootstrap/Form'
 //import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
-import Dropdown from 'react-bootstrap/Dropdown'
+//import Dropdown from 'react-bootstrap/Dropdown'
 //import Button from 'react-bootstrap/Button'
 import {VictoryChart, VictoryBar, VictoryAxis, VictoryLegend} from 'victory' // VictoryTheme, VictoryLabel
 //import { orderBy } from 'lodash'
@@ -55,26 +55,8 @@ export default class MyBarChart extends Component {
         //this.handleOpinionMaxChange = this.handleOpinionMaxChange.bind(this)
         this.handleCategoryCheck = this.handleCategoryCheck.bind(this)
         this.handleModelSelect = this.handleModelSelect.bind(this)
-
-        // SHOW ME (STATE MANIPULATION SHORTCUTS)
-
-        this.showUsersMostFollowed = this.showUsersMostFollowed.bind(this)
-        this.showUsersMostActive = this.showUsersMostActive.bind(this)
-        this.showUsersMostLeftLeaning = this.showUsersMostLeftLeaning.bind(this)
-        this.showUsersMostRightLeaning = this.showUsersMostRightLeaning.bind(this)
-        this.showUsersMostNeutral = this.showUsersMostNeutral.bind(this)
-
-        this.showMediaMostFollowed = this.showMediaMostFollowed.bind(this)
-        this.showMediaMostActive = this.showMediaMostActive.bind(this)
-        this.showMediaMostLeftLeaning = this.showMediaMostLeftLeaning.bind(this)
-        this.showMediaMostRightLeaning = this.showMediaMostRightLeaning.bind(this)
-        this.showMediaMostNeutral = this.showMediaMostNeutral.bind(this)
-
-        this.showPolsMostFollowed = this.showPolsMostFollowed.bind(this)
-        this.showPolsMostActive = this.showPolsMostActive.bind(this)
-        this.showPolsMostLeftLeaning = this.showPolsMostLeftLeaning.bind(this)
-        this.showPolsMostRightLeaning = this.showPolsMostRightLeaning.bind(this)
-        this.showPolsMostNeutral = this.showPolsMostNeutral.bind(this)
+        this.handleCategorySelect = this.handleCategorySelect.bind(this)
+        this.handleMetricSelect = this.handleMetricSelect.bind(this)
     }
 
     handleTweetMinChange(changeEvent){
@@ -108,78 +90,17 @@ export default class MyBarChart extends Component {
         this.setState({"opinionModel": model})
     }
 
-    // ALL USERS
-
-    showUsersMostFollowed(){
-        console.log("SHOW ME: USERS MOST FOLLOWED") // currently sorted to users most followed, so just open all params
-        //var currentModel = this.state.opinionModel //TODO: use currently-selected opinionModel
-        this.setState({tweetMin: 3, opinionRange: [0, 100], userCategories: allCategoryNames, opinionModel: "lr"})
-    }
-    showUsersMostActive(){
-        console.log("SHOW ME: USERS MOST ACTIVE")
-        this.setState({tweetMin: 200, opinionRange: [0, 100], userCategories: allCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showUsersMostLeftLeaning(){
-        console.log("SHOW ME: USERS MOST LEFT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [0, 10], userCategories: allCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showUsersMostRightLeaning(){
-        console.log("SHOW ME: USERS MOST RIGHT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [90, 100], userCategories: allCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showUsersMostNeutral(){
-        console.log("SHOW ME: USERS MOST NEUTRAL")
-        this.setState({tweetMin: 3, opinionRange: [45, 55], userCategories: allCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
+    handleCategorySelect(changeEvent){
+        var val = changeEvent.target.value
+        console.log("SHOW ME CATEGORY:", val)
+        //this.setState({"opinionModel": model})
     }
 
-    // MEDIA
-
-    showMediaMostFollowed(){
-        console.log("SHOW ME: MEDIA MOST FOLLOWED") // currently sorted to users most followed, so just open all params
-        this.setState({tweetMin: 3, opinionRange: [0, 100], userCategories: mediaCategoryNames, opinionModel: "lr"})
+    handleMetricSelect(changeEvent){
+        var val = changeEvent.target.value
+        console.log("SHOW ME METRIC:", val)
+        //this.setState({"opinionModel": model})
     }
-    showMediaMostActive(){
-        console.log("SHOW ME: MEDIA MOST ACTIVE")
-        this.setState({tweetMin: 200, opinionRange: [0, 100], userCategories: mediaCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showMediaMostLeftLeaning(){
-        console.log("SHOW ME: MEDIA MOST LEFT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [0, 20], userCategories: mediaCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showMediaMostRightLeaning(){
-        console.log("SHOW ME: MEDIA MOST RIGHT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [70, 100], userCategories: mediaCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showMediaMostNeutral(){
-        console.log("SHOW ME: MEDIA MOST NEUTRAL")
-        this.setState({tweetMin: 3, opinionRange: [30, 70], userCategories: mediaCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-
-    // POLITICIANS
-
-    showPolsMostFollowed(){
-        console.log("SHOW ME: POLITICIANS MOST FOLLOWED") // currently sorted to users most followed, so just open all params
-        //var currentModel = this.state.opinionModel //TODO: use currently-selected opinionModel
-        this.setState({tweetMin: 3, opinionRange: [0, 100], userCategories: polCategoryNames, opinionModel: "lr"})
-    }
-    showPolsMostActive(){
-        console.log("SHOW ME: POLITICIANS MOST ACTIVE")
-        this.setState({tweetMin: 75, opinionRange: [0, 100], userCategories: polCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showPolsMostLeftLeaning(){
-        console.log("SHOW ME: POLITICIANS MOST LEFT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [0, 5], userCategories: polCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showPolsMostRightLeaning(){
-        console.log("SHOW ME: POLITICIANS MOST RIGHT-LEANING")
-        this.setState({tweetMin: 3, opinionRange: [90, 100], userCategories: polCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-    showPolsMostNeutral(){
-        console.log("SHOW ME: POLITICIANS MOST NEUTRAL")
-        this.setState({tweetMin: 3, opinionRange: [35, 65], userCategories: polCategoryNames, opinionModel: "lr"}) // TODO: use currently-selected opinionModel
-    }
-
-
 
     render() {
         var tweetMin = this.state.tweetMin
@@ -225,6 +146,7 @@ export default class MyBarChart extends Component {
         return (
             <span>
 
+                { /*
                 <Dropdown>
                     <Dropdown.Toggle variant="light" id="dropdown-basic">
                         Show Me
@@ -254,6 +176,7 @@ export default class MyBarChart extends Component {
                     </Dropdown.Menu>
                 </Dropdown>
 
+                */}
                 <p className="app-center chart-title-p" style={{marginTop:10, marginBottom:0}}>{chartTitle}</p>
                 <h4 className="app-center chart-title-h4" style={{marginTop:10, marginBottom:0}}>{chartTitle}</h4>
 
@@ -351,35 +274,31 @@ export default class MyBarChart extends Component {
                     />
                 </VictoryChart>
 
-                <Form style={{marginTop: -50}}>
+                <Form style={{marginTop: -75}}>
                     <Form.Group as={Row}>
-                        <Col xs="5">
-                            <Form.Label>Show Me</Form.Label>
-                            <Form.Control as="select" size="lg" custom>
-                                <option>1</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
+                        <Col xs="6">
+                            <Form.Label>Show Me:</Form.Label>
+                            <Form.Control as="select" size="lg" custom onChange={this.handleCategorySelect}>
+                                <option value="all">All Users</option>
+                                <option value="media">Media</option>
+                                <option value="pol">Politicians</option>
+                                {/* <option value="comment">Commentators</option> */}
                             </Form.Control>
                         </Col>
 
-                        <Col xs="1">
-                        </Col>
-
-                        <Col xs="5">
+                        <Col xs="6">
                             <Form.Label>&nbsp;</Form.Label>
-                            <Form.Control as="select" size="lg" custom>
-                                <option>1</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
+                            <Form.Control as="select" size="lg" custom onChange={this.handleMetricSelect}>
+                                <option value="most-followed">Most Followed</option>
+                                <option value="most-active">Most Active</option>
+                                <option value="most-pro-trump">Most Pro-Trump</option>
+                                <option value="most-pro-impeachment">Most Pro-Impeachment</option>
+                                {/* <option value="most-neutral">Most Neutral</option> */}
                             </Form.Control>
                         </Col>
                     </Form.Group>
 
-                    <Form.Group as={Row}>
+                    <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
                             <Form.Label>Minimum Tweet Count</Form.Label>
 
@@ -436,7 +355,7 @@ export default class MyBarChart extends Component {
                         </Col>  */}
                     </Form.Group>
 
-                    <Form.Group as={Row}>
+                    <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
                             <Form.Label>User Category</Form.Label>
 

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -213,7 +213,7 @@ export default class MyBarChart extends Component {
                 <Form style={{marginTop: -75}}>
                     <Form.Group as={Row}>
                         <Col xs="6">
-                            <Form.Label>Filter By:</Form.Label>
+                            <Form.Label>User Category:</Form.Label>
                             <Form.Control as="select" size="lg" custom onChange={this.handleCategorySelect}>
                                 <option value="all">All Users</option>
                                 <option value="media">Media</option>
@@ -324,7 +324,7 @@ export default class MyBarChart extends Component {
 
 
 
-
+                    {/*
                     <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
                             <Form.Label>User Category:</Form.Label>
@@ -342,6 +342,8 @@ export default class MyBarChart extends Component {
                         <Col xs="5">
                         </Col>
                     </Form.Group>
+
+                    */}
                 </Form>
             </span>
         )

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -36,6 +36,10 @@ const FILTER_CATEGORIES = {
     "all": ALL_CATEGORY_NAMES,
     "media": ["MAJOR-MEDIA-OUTLET", "MEDIA-OUTLET", "NEWS-SHOW"],
     "politician": ["ELECTED-OFFICIAL", "PARTY", "GOVERNMENT"],
+    "commentator": ["POLITICAL-COMMENTATOR", "LEGAL-SCHOLAR"],
+    "celebrity": ["CELEBRITY"],
+
+
 }
 const SORT_METRICS = {
     "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count"},
@@ -218,7 +222,8 @@ export default class MyBarChart extends Component {
                                 <option value="all">All Users</option>
                                 <option value="media">Media</option>
                                 <option value="politician">Politicians</option>
-                                {/* <option value="comment">Commentators</option> */}
+                                <option value="commentator">Commentators</option>
+                                <option value="celebrity">Celebrities</option>
                             </Form.Control>
                         </Col>
 
@@ -285,7 +290,7 @@ export default class MyBarChart extends Component {
 
                     <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
-                            <Form.Label>Minimum Tweet Count:</Form.Label>
+                            <Form.Label>Minimum Tweets:</Form.Label>
 
                             <RangeSlider min={3} max={200}
                                 value={tweetMin}

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -214,7 +214,7 @@ export default class MyBarChart extends Component {
                     />
                 </VictoryChart>
 
-                <Form style={{marginTop: -75}}>
+                <Form className="below-chart">
                     <Form.Group as={Row}>
                         <Col xs="6">
                             <Form.Label>User Category:</Form.Label>

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -54,8 +54,11 @@ export default class MyBarChart extends Component {
     constructor(props) {
         super(props)
         this.state = { // TODO: get URL params from router, so we can make custom charts and link people to them, like ?opinionMin=40&opinionMax=60&tweetMin=10
+
+            //sortMetric: "most-followed",
             sortMetric: "follower_count", // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
             sortOrder: "desc", // "desc", "asc"
+            sortLabel: "Follower Count", // "desc", "asc"
 
             tweetMin: 5,
             followerMin: 10000,
@@ -89,6 +92,7 @@ export default class MyBarChart extends Component {
             sortMetric = opinionMetric
         }
         var sortOrder = this.state.sortOrder
+        var sortLabel = this.state.sortLabel
 
         // FILTER AND SORT USERS
 
@@ -129,17 +133,9 @@ export default class MyBarChart extends Component {
 
         // CHART OPTIONS
 
-
-        var metricLabel = "Follower Count"
-
-
         var chartTitle = "Users Tweeting about Trump Impeachment" // TODO: dynamic
         var chartPadding = { left: 175, top: 15, right: 50, bottom: 130 } // spacing for axis labels (screen names)
         var domainPadding = { x: [10,0] } // spacing between bottom bar and bottom axis
-
-
-
-
 
         return (
             <span>
@@ -201,7 +197,7 @@ export default class MyBarChart extends Component {
                     <VictoryAxis dependentAxis
                         //tickFormat={(tick) => `${tick}%`}
                         tickFormat={formatBigNumber}
-                        label={metricLabel}
+                        label={sortLabel}
                         style={{
                             //axis: {stroke: "#756f6a"},
                             axisLabel: {fontSize: 10, padding:25},
@@ -238,7 +234,7 @@ export default class MyBarChart extends Component {
 
                     <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
-                            <Form.Label>Minimum Follower Count</Form.Label>
+                            <Form.Label>Minimum Followers:</Form.Label>
 
                             <RangeSlider min={10000} max={1000000} step={10000}
                                 value={followerMin}
@@ -254,7 +250,7 @@ export default class MyBarChart extends Component {
                         </Col>
 
                         <Col xs="5">
-                            <Form.Label>Mean Opinion Score</Form.Label>
+                            <Form.Label>Mean Opinion Score:</Form.Label>
 
                             <Range min={0} max={100} step={1}
                                 defaultValue={[0, 100]}
@@ -287,7 +283,7 @@ export default class MyBarChart extends Component {
 
                     <Form.Group as={Row} style={{marginTop: 35}}>
                         <Col xs="5">
-                            <Form.Label>Minimum Tweet Count</Form.Label>
+                            <Form.Label>Minimum Tweet Count:</Form.Label>
 
                             <RangeSlider min={3} max={200}
                                 value={tweetMin}
@@ -299,31 +295,11 @@ export default class MyBarChart extends Component {
                             />
                         </Col>
 
-                        <Col xs="7">
-                        </Col>
-                    </Form.Group>
-
-
-
-
-
-
-                    <Form.Group as={Row} style={{marginTop: 35}}>
-                        <Col xs="5">
-                            <Form.Label>User Category</Form.Label>
-
-                            <div key="inline-checkbox" className="mb-3">
-                                {categoryChecks}
-                            </div>
-
-                            <p>NOTE: categories are subjective</p>
-                        </Col>
-
                         <Col xs="1">
                         </Col>
 
                         <Col xs="5">
-                            <Form.Label>Opinion Model</Form.Label>
+                            <Form.Label>Opinion Model:</Form.Label>
 
                             <div key="inline-radios" className="mb-3">
                                 <Form.Check inline label="Logistic Regression" value="lr" type="radio" id="radio-lr"
@@ -339,6 +315,29 @@ export default class MyBarChart extends Component {
                                     onChange={this.handleModelSelect}
                                 />
                             </div>
+                        </Col>
+                    </Form.Group>
+
+
+
+
+
+
+                    <Form.Group as={Row} style={{marginTop: 35}}>
+                        <Col xs="5">
+                            <Form.Label>User Category:</Form.Label>
+
+                            <div key="inline-checkbox" className="mb-3">
+                                {categoryChecks}
+                            </div>
+
+                            <p>NOTE: categories are subjective</p>
+                        </Col>
+
+                        <Col xs="1">
+                        </Col>
+
+                        <Col xs="5">
                         </Col>
                     </Form.Group>
                 </Form>
@@ -398,7 +397,11 @@ export default class MyBarChart extends Component {
     handleMetricSelect(changeEvent){
         var val = changeEvent.target.value
         console.log("SORT BY METRIC:", val)
-        this.setState({sortMetric: SORT_METRICS[val]["metric"], sortOrder: SORT_METRICS[val]["order"]})
+        this.setState({
+            sortMetric: SORT_METRICS[val]["metric"],
+            sortOrder: SORT_METRICS[val]["order"],
+            sortLabel: SORT_METRICS[val]["label"]
+        })
     }
 
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -126,17 +126,6 @@ export default class MyBarChart extends Component {
             }) // sort before slice
             .slice(-BAR_COUNT) // negative number takes last X users (which is actually the top X users)
 
-        // CHART CONTROLS
-
-        var categoryChecks = ALL_CATEGORIES.map(function(category){
-            return (
-                <Form.Check inline type="checkbox" key={category["name"]} value={category["name"]} label={category["label"]}
-                    checked={userCategories.includes(category["name"])}
-                    onChange={handleCategoryCheck}
-                />
-            )
-        })
-
         // CHART OPTIONS
 
         var chartTitle = "Users Tweeting about Trump Impeachment" // TODO: dynamic
@@ -324,31 +313,6 @@ export default class MyBarChart extends Component {
                             </div>
                         </Col>
                     </Form.Group>
-
-
-
-
-
-                    {/*
-                    <Form.Group as={Row} style={{marginTop: 35}}>
-                        <Col xs="5">
-                            <Form.Label>User Category:</Form.Label>
-
-                            <div key="inline-checkbox" className="mb-3">
-                                {categoryChecks}
-                            </div>
-
-                            <p>NOTE: categories are subjective</p>
-                        </Col>
-
-                        <Col xs="1">
-                        </Col>
-
-                        <Col xs="5">
-                        </Col>
-                    </Form.Group>
-
-                    */}
                 </Form>
             </span>
         )

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChartV1.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChartV1.js
@@ -257,6 +257,12 @@ export default class MyBarChart extends Component {
                 <p className="app-center chart-title-p" style={{marginTop:10, marginBottom:0}}>{chartTitle}</p>
                 <h4 className="app-center chart-title-h4" style={{marginTop:10, marginBottom:0}}>{chartTitle}</h4>
 
+                {/*
+
+                <VictoryLabel text={chartTitle} textAnchor="center"/>
+
+                */}
+
                 <VictoryLegend height={15}
                     //title="Opinion Score" centerTitle
                     orientation="horizontal"
@@ -278,6 +284,7 @@ export default class MyBarChart extends Component {
                         labels: {fontSize: 10},
                     }}
                 />
+
 
                 <VictoryChart padding={chartPadding} domainPadding={domainPadding} >
                     { /*
@@ -352,33 +359,6 @@ export default class MyBarChart extends Component {
                 </VictoryChart>
 
                 <Form style={{marginTop: -50}}>
-                    <Form.Group as={Row}>
-                        <Col xs="5">
-                            <Form.Label>Show Me</Form.Label>
-                            <Form.Control as="select" size="lg" custom>
-                                <option>1</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Form.Control>
-                        </Col>
-
-                        <Col xs="1">
-                        </Col>
-
-                        <Col xs="5">
-                            <Form.Label>&nbsp;</Form.Label>
-                            <Form.Control as="select" size="lg" custom>
-                                <option>1</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Form.Control>
-                        </Col>
-                    </Form.Group>
-
                     <Form.Group as={Row}>
                         <Col xs="5">
                             <Form.Label>Minimum Tweet Count</Form.Label>

--- a/src/_App/OpinionAnalysis/User/Dashboard.js
+++ b/src/_App/OpinionAnalysis/User/Dashboard.js
@@ -6,6 +6,7 @@ import Form from 'react-bootstrap/Form'
 //import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
+import ReactGA from 'react-ga'
 
 import Spinner from '../../Spinner'
 import UserStatusesTable from './UserStatusesTable.js'
@@ -24,6 +25,11 @@ export default class Dashboard extends PureComponent {
     handleModelSelect(changeEvent){
         var metric = changeEvent.target.value
         console.log("SELECT METRIC:", metric)
+        ReactGA.event({
+            category: "User Chart Interaction",
+            action: "Select Opinion Model",
+            value: metric
+        })
         this.setState({"metric": metric})
     }
 

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -10,6 +10,7 @@ import Form from 'react-bootstrap/Form'
 //import InputGroup from 'react-bootstrap/InputGroup'
 import Button from 'react-bootstrap/Button'
 import queryString from 'query-string'
+import ReactGA from 'react-ga'
 
 import UserOpinionDashboard from "./Dashboard"
 
@@ -27,6 +28,11 @@ export default class UserOpinionSection extends PureComponent {
         event.preventDefault() // prevent page reload
         var screenName = document.getElementById("inputScreenName").value
         console.log("YOU CLICKED ME!", screenName)
+        ReactGA.event({
+            category: "User Chart Interaction",
+            action: "Input Screen Name",
+            value: screenName
+        })
         this.setState({screenName: screenName})
     }
 

--- a/src/_App/TweetCollection/Topics/Section.js
+++ b/src/_App/TweetCollection/Topics/Section.js
@@ -26,7 +26,7 @@ export default function Section() {
                     <Card.Title><h3>Collection Topics</h3></Card.Title>
 
                     <Card.Text>
-                        We collected any tweets mentioning any of the impeachment-related topics below. We periodically added new topics to reflect conversation trends about current events.
+                        We collected tweets mentioning any of the impeachment-related topics below. We periodically added new topics to reflect conversation trends about current events.
                     </Card.Text>
 
                     {/*

--- a/src/_App/TweetCollection/Topics/Section.js
+++ b/src/_App/TweetCollection/Topics/Section.js
@@ -26,7 +26,7 @@ export default function Section() {
                     <Card.Title><h3>Collection Topics</h3></Card.Title>
 
                     <Card.Text>
-                        Specifically, we collected all tweets mentioning any of the impeachment-related topics below. We periodically added new topics to reflect conversation trends about current events.
+                        We collected any tweets mentioning any of the impeachment-related topics below. We periodically added new topics to reflect conversation trends about current events.
                     </Card.Text>
 
                     {/*


### PR DESCRIPTION
Enable sorting of the top users chart based on other metrics besides follower count (status count, pro-trump score, pro-impeachment score). Replaces user category check-boxes with a select box. Adds slider for minimum follower count.