### PR TITLE
Inverse Opinon Scores

### DIFF
--- a/src/_App/OpinionAnalysis/TopUsers/Section.js
+++ b/src/_App/OpinionAnalysis/TopUsers/Section.js
@@ -21,7 +21,7 @@ export default function TopUserOpinion() {
 
                     <Card.Text>
                         The chart below shows mean impeachment opinion scores for the users in our dataset who have the most followers.
-                        {" "}NOTE: follower counts represent users in our dataset only - actual Twitter follower counts will be higher.
+                        {" "}NOTE: follower and tweet counts represent users and tweets in our dataset only.
                     </Card.Text>
                 </Card.Body>
             </Card>

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -44,11 +44,11 @@ const FILTER_CATEGORIES = {
 }
 const SORT_METRICS = {
     "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count (in our dataset)"},
-    "most-active": {"metric": "status_count", "order": "desc", "label": "Tweet Count"},
+    "most-active": {"metric": "status_count", "order": "desc", "label": "Tweet Count (in our dataset)"},
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
 }
-const DEFAULT_METRIC = "most-pro-impeachment" // "most-pro-trump" // "most-followed"
+const DEFAULT_METRIC = "most-pro-trump" // "most-pro-trump" // "most-followed"
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
 
 function formatBigNumber(num) {
@@ -61,6 +61,7 @@ export default class MyBarChart extends Component {
         super(props)
         this.state = { // TODO: get URL params from router, so we can make custom charts and link people to them, like ?opinionMin=40&opinionMax=60&tweetMin=10
 
+            sortVal: DEFAULT_METRIC,
             sortMetric: SORT_METRICS[DEFAULT_METRIC]["metric"], // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
             sortOrder:  SORT_METRICS[DEFAULT_METRIC]["order"], // "desc", "asc"
             sortLabel:  SORT_METRICS[DEFAULT_METRIC]["label"], // "desc", "asc"
@@ -95,6 +96,7 @@ export default class MyBarChart extends Component {
         var barLabel = this.barLabel
         var barSizeMetric = this.barSizeMetric
 
+        var sortVal = this.state.sortVal
         var sortMetric = this.state.sortMetric
         if(sortMetric === "opinion_score"){
             sortMetric = opinionMetric
@@ -220,10 +222,10 @@ export default class MyBarChart extends Component {
                         <Col xs="6">
                             <Form.Label>Sort By:</Form.Label>
                             <Form.Control as="select" size="lg" custom onChange={this.handleMetricSelect}>
-                                <option value="most-followed">Follower Count</option>
-                                <option value="most-active">Tweet Count</option>
-                                <option value="most-pro-trump">Pro-Trump Score</option>
-                                <option value="most-pro-impeachment">Pro-Impeachment Score</option>
+                                <option value="most-followed" selected={sortVal === "most-followed"}>Follower Count</option>
+                                <option value="most-active" selected={sortVal === "most-active"}>Tweet Count</option>
+                                <option value="most-pro-trump" selected={sortVal === "most-pro-trump"}>Pro-Trump Score</option>
+                                <option value="most-pro-impeachment" selected={sortVal === "most-pro-impeachment"}>Pro-Impeachment Score</option>
                                 {/* <option value="most-neutral">Most Neutral</option> */}
                             </Form.Control>
                         </Col>
@@ -417,6 +419,7 @@ export default class MyBarChart extends Component {
             label: val
         })
         this.setState({
+            sortVal: val,
             sortMetric: SORT_METRICS[val]["metric"],
             sortOrder: SORT_METRICS[val]["order"],
             sortLabel: SORT_METRICS[val]["label"]

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -70,8 +70,7 @@ export default class MyBarChart extends Component {
             opinionRange: [0, 100],
             userCategories: ALL_CATEGORY_NAMES,
 
-            opinionModel: "lr",
-            //opinionModel: "avg_score_lr",
+            opinionMetric: "avg_score_lr",
         }
         this.handleTweetMinChange = this.handleTweetMinChange.bind(this)
         this.handleFollowerMinChange = this.handleFollowerMinChange.bind(this)
@@ -91,8 +90,7 @@ export default class MyBarChart extends Component {
         var followerMin = this.state.followerMin
         var opinionRange = this.state.opinionRange
         var userCategories = this.state.userCategories
-        var opinionModel = this.state.opinionModel
-        var opinionMetric = `avg_score_${opinionModel}` // this.state.opinionMetric
+        var opinionMetric = this.state.opinionMetric
         var barLabel = this.barLabel
         //var barSize = this.barSize
 
@@ -300,16 +298,16 @@ export default class MyBarChart extends Component {
                             <Form.Label>Opinion Model:</Form.Label>
 
                             <div key="inline-radios" className="mb-3">
-                                <Form.Check inline label="Logistic Regression" value="lr" type="radio" id="radio-lr"
-                                    checked={opinionModel === "lr"}
+                                <Form.Check inline label="Logistic Regression" value="avg_score_lr" type="radio"
+                                    checked={opinionMetric === "avg_score_lr"}
                                     onChange={this.handleModelSelect}
                                 />
-                                <Form.Check inline label="Naive Bayes" value="nb" type="radio" id="radio-nb"
-                                    checked={opinionModel === "nb"}
+                                <Form.Check inline label="Naive Bayes" value="avg_score_nb" type="radio"
+                                    checked={opinionMetric === "avg_score_nb"}
                                     onChange={this.handleModelSelect}
                                 />
-                                <Form.Check inline label="BERT Transformer" value="bert" type="radio" id="radio-bert"
-                                    checked={opinionModel === "bert"}
+                                <Form.Check inline label="BERT Transformer" value="avg_score_bert" type="radio"
+                                    checked={opinionMetric === "avg_score_bert"}
                                     onChange={this.handleModelSelect}
                                 />
                             </div>
@@ -388,14 +386,14 @@ export default class MyBarChart extends Component {
     }
 
     handleModelSelect(changeEvent){
-        var model = changeEvent.target.value
-        console.log("SELECT MODEL:", model)
+        var opinionMetric = changeEvent.target.value
+        console.log("SELECT OPINION METRIC:", opinionMetric)
         ReactGA.event({
             category: "Top Users Chart Interaction",
             action: "Select Opinion Model",
-            label: model
+            label: opinionMetric
         })
-        this.setState({"opinionModel": model})
+        this.setState({"opinionMetric": opinionMetric})
     }
 
     handleCategorySelect(changeEvent){

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -144,7 +144,7 @@ export default class MyBarChart extends Component {
                         { name: "Pro-Impeachment (0%)", symbol: { fill: colorScale(0.15), type: "circle" } },
                         { name: "Pro-Trump (100%)",     symbol: { fill: colorScale(0.85), type: "circle"} },
                     ]}
-                    //gutter={20}
+                    gutter={15} // number of pixels between legend columns
                     x={120}
                     y={-3}
                     //width={20}

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -139,6 +139,14 @@ export default class MyBarChart extends Component {
         var chartPadding = { left: 175, top: 15, right: 50, bottom: 130 } // spacing for axis labels (screen names)
         var domainPadding = { x: [10,0] } // spacing between bottom bar and bottom axis
 
+        var legendData = [
+            { name: "Pro-Impeachment (0%)", symbol: { fill: colorScale(0.15), type: "circle" } },
+            { name: "Pro-Trump (100%)",     symbol: { fill: colorScale(0.85), type: "circle"} },
+        ]
+        if (sortVal === "most-pro-impeachment"){
+            legendData.reverse() // mutating
+        }
+
         return (
             <span>
                 <p className="app-center chart-title-p" style={{marginTop:10, marginBottom:0}}>{chartTitle}</p>
@@ -147,10 +155,7 @@ export default class MyBarChart extends Component {
                 <VictoryLegend height={17}
                     //title="Opinion Score" centerTitle
                     orientation="horizontal"
-                    data={[
-                        { name: "Pro-Impeachment (0%)", symbol: { fill: colorScale(0.15), type: "circle" } },
-                        { name: "Pro-Trump (100%)",     symbol: { fill: colorScale(0.85), type: "circle"} },
-                    ]}
+                    data={legendData}
                     gutter={15} // number of pixels between legend columns
                     x={120}
                     y={0}
@@ -440,13 +445,13 @@ export default class MyBarChart extends Component {
     }
 
     barSizeMetric(){
+        var sortVal = this.state.sortVal
         var sortMetric = this.state.sortMetric
-        var sortOrder = this.state.sortOrder
         var opinionMetric = this.state.opinionMetric
 
-        if (sortMetric == "opinion_score" && sortOrder === "asc"){
+        if (sortVal === "most-pro-impeachment"){
             return "inverse_score"
-        } else if(sortMetric === "opinion_score" && sortOrder === "desc") {
+        } else if(sortVal === "most-pro-trump") {
             return opinionMetric
         } else {
             return sortMetric
@@ -454,17 +459,15 @@ export default class MyBarChart extends Component {
     }
 
     axisTick(datum){
-        var sortMetric = this.state.sortMetric
-        var sortOrder = this.state.sortOrder
         // REVERSE THE AXIS NUMBERS WHEN BAR SIZES ARE INVERSED
-        if (sortMetric === "opinion_score" && sortOrder === "asc"){
+        var sortVal = this.state.sortVal
+
+        if (sortVal === "most-pro-impeachment"){
             // var d = (0.199999999999999999996 * .9999999)
             // d.toFixed(1) //> 0.2
             return formatBigNumber((1-datum).toFixed(1))
         } else {
             return formatBigNumber(datum)
         }
-
-
     }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -69,7 +69,9 @@ export default class MyBarChart extends Component {
             tweetMin: 30,
             opinionRange: [0, 100],
             userCategories: ALL_CATEGORY_NAMES,
+
             opinionModel: "lr",
+            //opinionModel: "avg_score_lr",
         }
         this.handleTweetMinChange = this.handleTweetMinChange.bind(this)
         this.handleFollowerMinChange = this.handleFollowerMinChange.bind(this)
@@ -81,7 +83,7 @@ export default class MyBarChart extends Component {
         this.handleCategorySelect = this.handleCategorySelect.bind(this)
         this.handleMetricSelect = this.handleMetricSelect.bind(this)
         this.barLabel = this.barLabel.bind(this)
-
+        //this.barSize = this.barSize.bind(this)
     }
 
     render() {
@@ -90,8 +92,9 @@ export default class MyBarChart extends Component {
         var opinionRange = this.state.opinionRange
         var userCategories = this.state.userCategories
         var opinionModel = this.state.opinionModel
-        var opinionMetric = `avg_score_${opinionModel}`
+        var opinionMetric = `avg_score_${opinionModel}` // this.state.opinionMetric
         var barLabel = this.barLabel
+        //var barSize = this.barSize
 
         var sortMetric = this.state.sortMetric
         if(sortMetric === "opinion_score"){
@@ -138,7 +141,7 @@ export default class MyBarChart extends Component {
                 <p className="app-center chart-title-p" style={{marginTop:10, marginBottom:0}}>{chartTitle}</p>
                 <h4 className="app-center chart-title-h4" style={{marginTop:10, marginBottom:0}}>{chartTitle}</h4>
 
-                <VictoryLegend height={15}
+                <VictoryLegend height={17}
                     //title="Opinion Score" centerTitle
                     orientation="horizontal"
                     data={[
@@ -147,7 +150,7 @@ export default class MyBarChart extends Component {
                     ]}
                     gutter={15} // number of pixels between legend columns
                     x={120}
-                    y={-3}
+                    y={0}
                     //width={20}
                     style={{
                         //parent: {},
@@ -161,7 +164,7 @@ export default class MyBarChart extends Component {
                 <VictoryChart padding={chartPadding} domainPadding={domainPadding} >
 
                     <VictoryBar horizontal
-                        data={users} x="handle" y={"inverse_score"} // sortMetric or barSize
+                        data={users} x="handle" y={sortMetric} // barSize() sortMetric or "inverse_score"
                         animate={true}
                         //barWidth={12}
                         barRatio={0.87}
@@ -431,13 +434,17 @@ export default class MyBarChart extends Component {
 
     }
 
-    barSize(datum){
-        var metric = this.state.sortMetric
-        //if (metric == "opinion_score"){
-        //    return datum["scorePct"]
-        //} else {
-        //    return formatBigNumber(datum[metric])
-        //}
-
-    }
+    //barSize(){
+    //    var sortMetric = this.state.sortMetric
+    //    var sortOrder = this.state.sortOrder
+    //    var opinionMetric = this.state.opinionMetric
+    //    console.log("BAR SIZE", sortMetric, sortOrder, opinionMetric)
+//
+    //    //debugger;
+    //    if (sortMetric == "opinion_score" && sortOrder == "asc"){
+    //        return "inverse_score"
+    //    } else {
+    //        return opinionMetric //sortMetric
+    //    }
+    //}
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -48,7 +48,7 @@ const SORT_METRICS = {
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
 }
-const DEFAULT_METRIC = "most-pro-impeachment" // "most-pro-trump" // "most-followed"
+const DEFAULT_METRIC = "most-pro-trump" // "most-pro-trump" // "most-followed"
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
 
 function formatBigNumber(num) {
@@ -229,11 +229,11 @@ export default class MyBarChart extends Component {
 
                         <Col xs="6">
                             <Form.Label>Sort By:</Form.Label>
-                            <Form.Control as="select" size="lg" custom onChange={this.handleMetricSelect}>
-                                <option value="most-followed" selected={sortVal === "most-followed"}>Follower Count</option>
-                                <option value="most-active" selected={sortVal === "most-active"}>Tweet Count</option>
-                                <option value="most-pro-trump" selected={sortVal === "most-pro-trump"}>Pro-Trump Score</option>
-                                <option value="most-pro-impeachment" selected={sortVal === "most-pro-impeachment"}>Pro-Impeachment Score</option>
+                            <Form.Control as="select" size="lg" custom value={sortVal} onChange={this.handleMetricSelect}>
+                                <option value="most-followed">Follower Count</option>
+                                <option value="most-active">Tweet Count</option>
+                                <option value="most-pro-trump">Pro-Trump Score</option>
+                                <option value="most-pro-impeachment">Pro-Impeachment Score</option>
                                 {/* <option value="most-neutral">Most Neutral</option> */}
                             </Form.Control>
                         </Col>

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -82,7 +82,7 @@ export default class MyBarChart extends Component {
         this.handleCategorySelect = this.handleCategorySelect.bind(this)
         this.handleMetricSelect = this.handleMetricSelect.bind(this)
         this.barLabel = this.barLabel.bind(this)
-        //this.barSize = this.barSize.bind(this)
+        this.barSizeMetric = this.barSizeMetric.bind(this)
     }
 
     render() {
@@ -91,8 +91,9 @@ export default class MyBarChart extends Component {
         var opinionRange = this.state.opinionRange
         var userCategories = this.state.userCategories
         var opinionMetric = this.state.opinionMetric
+
         var barLabel = this.barLabel
-        //var barSize = this.barSize
+        var barSizeMetric = this.barSizeMetric
 
         var sortMetric = this.state.sortMetric
         if(sortMetric === "opinion_score"){
@@ -162,7 +163,7 @@ export default class MyBarChart extends Component {
                 <VictoryChart padding={chartPadding} domainPadding={domainPadding} >
 
                     <VictoryBar horizontal
-                        data={users} x="handle" y={sortMetric} // barSize() sortMetric or "inverse_score"
+                        data={users} x="handle" y={barSizeMetric()} // barSize() sortMetric or "inverse_score"
                         animate={true}
                         //barWidth={12}
                         barRatio={0.87}
@@ -432,17 +433,18 @@ export default class MyBarChart extends Component {
 
     }
 
-    //barSize(){
-    //    var sortMetric = this.state.sortMetric
-    //    var sortOrder = this.state.sortOrder
-    //    var opinionMetric = this.state.opinionMetric
-    //    console.log("BAR SIZE", sortMetric, sortOrder, opinionMetric)
-//
-    //    //debugger;
-    //    if (sortMetric == "opinion_score" && sortOrder == "asc"){
-    //        return "inverse_score"
-    //    } else {
-    //        return opinionMetric //sortMetric
-    //    }
-    //}
+    barSizeMetric(){
+        var sortMetric = this.state.sortMetric
+        var sortOrder = this.state.sortOrder
+        var opinionMetric = this.state.opinionMetric
+        console.log("BAR SIZE", sortMetric, sortOrder, opinionMetric)
+
+        if (sortMetric == "opinion_score" && sortOrder == "asc"){
+            return "inverse_score"
+        } else if(sortMetric == "opinion_score" && sortOrder == "desc") {
+            return opinionMetric
+        } else {
+            return sortMetric
+        }
+    }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -43,12 +43,12 @@ const FILTER_CATEGORIES = {
 
 }
 const SORT_METRICS = {
-    "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count (in our dataset)"},
-    "most-active": {"metric": "status_count", "order": "desc", "label": "Tweet Count (in our dataset)"},
+    "most-followed": {"metric": "follower_count", "order": "desc", "label": "Follower Count"},
+    "most-active": {"metric": "status_count", "order": "desc", "label": "Tweet Count"},
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
 }
-const DEFAULT_METRIC = "most-pro-trump" // "most-pro-trump" // "most-followed"
+const DEFAULT_METRIC = "most-pro-impeachment" // "most-pro-trump" // "most-followed"
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
 
 function formatBigNumber(num) {
@@ -84,6 +84,7 @@ export default class MyBarChart extends Component {
         this.handleMetricSelect = this.handleMetricSelect.bind(this)
         this.barLabel = this.barLabel.bind(this)
         this.barSizeMetric = this.barSizeMetric.bind(this)
+        this.axisTick = this.axisTick.bind(this)
     }
 
     render() {
@@ -93,9 +94,6 @@ export default class MyBarChart extends Component {
         var userCategories = this.state.userCategories
         var opinionMetric = this.state.opinionMetric
 
-        var barLabel = this.barLabel
-        var barSizeMetric = this.barSizeMetric
-
         var sortVal = this.state.sortVal
         var sortMetric = this.state.sortMetric
         if(sortMetric === "opinion_score"){
@@ -103,6 +101,10 @@ export default class MyBarChart extends Component {
         }
         var sortOrder = this.state.sortOrder
         var sortLabel = this.state.sortLabel
+
+        var barLabel = this.barLabel
+        var barSizeMetric = this.barSizeMetric
+        var axisTick = this.axisTick
 
         // FILTER AND SORT USERS
 
@@ -193,8 +195,9 @@ export default class MyBarChart extends Component {
                         //tickFormat={["a", "b", "c", "d", "e"]}
                     />
                     <VictoryAxis dependentAxis
-                        //tickFormat={(tick) => `${tick}%`}
-                        tickFormat={formatBigNumber}
+                        //tickFormat={(tick) => `${1-tick}%`}
+                        //tickFormat={formatBigNumber}
+                        tickFormat={axisTick}
                         label={sortLabel}
                         style={{
                             //axis: {stroke: "#756f6a"},
@@ -440,14 +443,28 @@ export default class MyBarChart extends Component {
         var sortMetric = this.state.sortMetric
         var sortOrder = this.state.sortOrder
         var opinionMetric = this.state.opinionMetric
-        console.log("BAR SIZE", sortMetric, sortOrder, opinionMetric)
 
-        if (sortMetric == "opinion_score" && sortOrder == "asc"){
+        if (sortMetric == "opinion_score" && sortOrder === "asc"){
             return "inverse_score"
-        } else if(sortMetric == "opinion_score" && sortOrder == "desc") {
+        } else if(sortMetric === "opinion_score" && sortOrder === "desc") {
             return opinionMetric
         } else {
             return sortMetric
         }
+    }
+
+    axisTick(datum){
+        var sortMetric = this.state.sortMetric
+        var sortOrder = this.state.sortOrder
+        // REVERSE THE AXIS NUMBERS WHEN BAR SIZES ARE INVERSED
+        if (sortMetric === "opinion_score" && sortOrder === "asc"){
+            // var d = (0.199999999999999999996 * .9999999)
+            // d.toFixed(1) //> 0.2
+            return formatBigNumber((1-datum).toFixed(1))
+        } else {
+            return formatBigNumber(datum)
+        }
+
+
     }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -48,7 +48,7 @@ const SORT_METRICS = {
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
 }
-const DEFAULT_METRIC = "most-pro-trump" // "most-followed"
+const DEFAULT_METRIC = "most-pro-impeachment" // "most-pro-trump" // "most-followed"
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
 
 function formatBigNumber(num) {
@@ -113,7 +113,8 @@ export default class MyBarChart extends Component {
             )})
             .map(function(user){
                 user["handle"] = `@${user['screen_name']}`
-                user["scorePct"] = (user[opinionMetric] * 100.0).toFixed(1) + "%"
+                user["score_pct"] = (user[opinionMetric] * 100.0).toFixed(1) + "%"
+                user["inverse_score"] = (1 - user[opinionMetric]) // hack for reversing pro-impeachment bar sizes from 0.05 to 0.95
                 return user
             })
             .sort(function(a, b){
@@ -160,7 +161,7 @@ export default class MyBarChart extends Component {
                 <VictoryChart padding={chartPadding} domainPadding={domainPadding} >
 
                     <VictoryBar horizontal
-                        data={users} x="handle" y={sortMetric}
+                        data={users} x="handle" y={"inverse_score"} // sortMetric or barSize
                         animate={true}
                         //barWidth={12}
                         barRatio={0.87}
@@ -423,10 +424,20 @@ export default class MyBarChart extends Component {
     barLabel(datum){
         var metric = this.state.sortMetric
         if (metric == "opinion_score"){
-            return datum["scorePct"]
+            return datum["score_pct"]
         } else {
             return formatBigNumber(datum[metric])
         }
+
+    }
+
+    barSize(datum){
+        var metric = this.state.sortMetric
+        //if (metric == "opinion_score"){
+        //    return datum["scorePct"]
+        //} else {
+        //    return formatBigNumber(datum[metric])
+        //}
 
     }
 }

--- a/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
+++ b/src/_App/OpinionAnalysis/TopUsers/VBarChart.js
@@ -48,6 +48,7 @@ const SORT_METRICS = {
     "most-pro-trump": {"metric": "opinion_score", "order": "desc", "label": "Mean Opinion Score"},
     "most-pro-impeachment": {"metric": "opinion_score", "order": "asc", "label": "Mean Opinion Score"},
 }
+const DEFAULT_METRIC = "most-pro-trump" // "most-followed"
 var BAR_COUNT = 10 // would be nice to get 15 or 20 to work (with smaller bar labels)
 
 function formatBigNumber(num) {
@@ -60,12 +61,12 @@ export default class MyBarChart extends Component {
         super(props)
         this.state = { // TODO: get URL params from router, so we can make custom charts and link people to them, like ?opinionMin=40&opinionMax=60&tweetMin=10
 
-            sortMetric: SORT_METRICS["most-followed"]["metric"], // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
-            sortOrder:  SORT_METRICS["most-followed"]["order"], // "desc", "asc"
-            sortLabel:  SORT_METRICS["most-followed"]["label"], // "desc", "asc"
+            sortMetric: SORT_METRICS[DEFAULT_METRIC]["metric"], // can be "follower_count", "status_count", "opinion_score" (needs differentiation)
+            sortOrder:  SORT_METRICS[DEFAULT_METRIC]["order"], // "desc", "asc"
+            sortLabel:  SORT_METRICS[DEFAULT_METRIC]["label"], // "desc", "asc"
 
-            tweetMin: 5,
-            followerMin: 10000,
+            followerMin: 412_000,
+            tweetMin: 30,
             opinionRange: [0, 100],
             userCategories: ALL_CATEGORY_NAMES,
             opinionModel: "lr",
@@ -90,7 +91,6 @@ export default class MyBarChart extends Component {
         var userCategories = this.state.userCategories
         var opinionModel = this.state.opinionModel
         var opinionMetric = `avg_score_${opinionModel}`
-        var handleCategoryCheck = this.handleCategoryCheck
         var barLabel = this.barLabel
 
         var sortMetric = this.state.sortMetric
@@ -146,10 +146,8 @@ export default class MyBarChart extends Component {
                     ]}
                     //gutter={20}
                     x={120}
-                    y={0}
+                    y={-3}
                     //width={20}
-                    //height={10}
-                    //padding={{ top: 1000, bottom: 1000 }}
                     style={{
                         //parent: {},
                         //border: {stroke: "black"},


### PR DESCRIPTION
This approach improves how bars are displayed when sorting the top users chart by "Pro-Impeachment Score" which is a derived metric. It keeps the opinion score labels and scale the same for consistency (0: pro-impeachment, 1:pro-trump), but reverses the bar sizes and axis labels.

This is better than before, but may still be confusing for some viewers. There is a simpler way to do this that says just calculate the inverse opinion and use that in the charting. 