### PR TITLE
Typeahead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4562,6 +4562,11 @@
         "validate.io-positive-integer": "^1.0.0"
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
+      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4782,6 +4787,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
       }
     },
     "cross-spawn": {
@@ -8656,6 +8670,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -12571,6 +12590,11 @@
         "numeric": "^1.2.6"
       }
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -13973,6 +13997,56 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-bootstrap-typeahead": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-5.1.4.tgz",
+      "integrity": "sha512-CfoaSjGV3MZS9yrkLfYkvimzRYru1Ko7qKKzacbsBeZ/sHCxFvUhxnCXmTy/K2vZCkOmAQpU/sbgQVOkMRNlSQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "@restart/hooks": "^0.3.22",
+        "classnames": "^2.2.0",
+        "fast-deep-equal": "^3.1.1",
+        "invariant": "^2.2.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8",
+        "react-overlays": "^4.1.1",
+        "react-popper": "^1.0.0",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "@popperjs/core": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.4.tgz",
+          "integrity": "sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ=="
+        },
+        "react-overlays": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.1.tgz",
+          "integrity": "sha512-WtJifh081e6M24KnvTQoNjQEpz7HoLxqt8TwZM7LOYIkYJ8i/Ly1Xi7RVte87ZVnmqQ4PFaFiNHZhSINPSpdBQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.1",
+            "@popperjs/core": "^2.5.3",
+            "@restart/hooks": "^0.3.25",
+            "@types/warning": "^3.0.0",
+            "dom-helpers": "^5.2.0",
+            "prop-types": "^15.7.2",
+            "uncontrollable": "^7.0.0",
+            "warning": "^4.0.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.12.5",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+              "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -14312,6 +14386,20 @@
       "integrity": "sha512-nzir3uf+tFO1YXVUH5lFfD2plbDuZJXKrCO88KmRVnha2/zEhZBmZO8yS6GcRnLmSrhJkfmj6GTqWWvrJDBCBQ==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
       }
     },
     "react-resize-detector": {
@@ -15437,6 +15525,14 @@
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.26.tgz",
+      "integrity": "sha512-SQ6AOKfABaSchokAmmaxVnL9IArxEnLEX9j4wAZw+x4iUTb40q7irtHG3z4GtAWz5veVZcCnubXDBRyLVQaohw==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.16"
       }
     },
     "seedrandom": {
@@ -17302,6 +17398,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
       "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-bootstrap-range-slider": "^1.2.2",
+    "react-bootstrap-typeahead": "^5.1.4",
     "react-dom": "^16.13.1",
     "react-force-graph": "^1.37.1",
     "react-ga": "^3.1.2",

--- a/src/_App/App.js
+++ b/src/_App/App.js
@@ -12,6 +12,7 @@ import Col from 'react-bootstrap/Col'
 //import Card from 'react-bootstrap/Card'
 
 import 'bootstrap/dist/css/bootstrap.min.css'
+//import 'react-bootstrap-typeahead/css/Typeahead.css';
 import './App.css'
 
 //import Home from './Home.js'

--- a/src/_App/OpinionAnalysis/User/Dashboard.js
+++ b/src/_App/OpinionAnalysis/User/Dashboard.js
@@ -8,9 +8,9 @@ import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
 import ReactGA from 'react-ga'
 
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
-import Tooltip from 'react-bootstrap/Tooltip'
-import {QuestionIcon} from '@primer/octicons-react'
+//import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+//import Tooltip from 'react-bootstrap/Tooltip'
+//import {QuestionIcon} from '@primer/octicons-react'
 
 import Spinner from '../../Spinner'
 import UserStatusesTable from './UserStatusesTable.js'
@@ -29,9 +29,9 @@ const helperMessage = "The user's average Pro-Trump opinion score, as calculated
 //    {helperMessage}
 //</Tooltip>
 
-const modelSelectTooltip = <Tooltip id="model-select-tooltip">
-    See opinion scores from different Impeachment opinion models.
-</Tooltip>
+//const modelSelectTooltip = <Tooltip id="model-select-tooltip">
+//    See opinion scores from different Impeachment opinion models.
+//</Tooltip>
 
 export default class Dashboard extends PureComponent {
     constructor(props) {
@@ -99,10 +99,12 @@ export default class Dashboard extends PureComponent {
                         <Form style={{paddingTop:8}}>
                             <Form.Label>
                                 Opinion Model:
+                                {/*}
                                 {" "}
                                 <OverlayTrigger placement="top" overlay={modelSelectTooltip}>
                                     <span><QuestionIcon verticalAlign="text-top"/></span>
                                 </OverlayTrigger>
+                                */}
                             </Form.Label>
 
                             <div key="inline-radios" className="mb-3">

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -13,6 +13,7 @@ import { Typeahead } from 'react-bootstrap-typeahead'
 import queryString from 'query-string'
 import ReactGA from 'react-ga'
 
+//import {bigNumberLabel} from "../../Utils/Decorators"
 import UserOpinionDashboard from "./Dashboard"
 import users from "../TopUsers/data.js"
 
@@ -90,21 +91,21 @@ export default class UserOpinionSection extends PureComponent {
                                 <Col xs="auto">
                                     <Button type="submit" className="mb-2" variant="secondary" onClick={this.handleSubmit}>Submit</Button>
                                 </Col>
-
-
                             </Form.Row>
                         </Form>
                         */}
 
                         <Form.Group>
-                            <Form.Label>Change User:</Form.Label>
+                            <Form.Label>Change User (listed in order by follower count):</Form.Label>
                             <Typeahead
                                 id="top-users-typeahead"
-                                labelKey="screen_name"
                                 onChange={this.handleSelection}
                                 options={users}
                                 placeholder="SENATEMAJLDR"
                                 //selected={[this.state.screenName]}
+                                labelKey="screen_name"
+                                //labelKey={(option) => `${option.screen_name} (${bigNumberLabel(option.follower_count)} active followers)`}
+                                //labelKey={(option) => `${option.screen_name} (${bigNumberLabel(option.follower_count)} active followers, ${option.status_count} tweets)`}
                             />
                         </Form.Group>
 
@@ -114,14 +115,9 @@ export default class UserOpinionSection extends PureComponent {
                 <Card>
                     <Card.Body>
                         {/*
-
                         {screenName}
-
                         */}
-
                         <UserOpinionDashboard key={screenName} screenName={screenName}/>
-
-
                     </Card.Body>
                 </Card>
             </Container>

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -9,10 +9,131 @@ import Form from 'react-bootstrap/Form'
 //import FormControl from 'react-bootstrap/FormControl'
 //import InputGroup from 'react-bootstrap/InputGroup'
 import Button from 'react-bootstrap/Button'
+import { Typeahead } from 'react-bootstrap-typeahead'
 import queryString from 'query-string'
 import ReactGA from 'react-ga'
 
 import UserOpinionDashboard from "./Dashboard"
+
+
+
+
+
+const exampleOptions = [
+  { name: 'Alabama', population: 4780127, capital: 'Montgomery', region: 'South' },
+  { name: 'Alaska', population: 710249, capital: 'Juneau', region: 'West' },
+  { name: 'Arizona', population: 6392307, capital: 'Phoenix', region: 'West' },
+  { name: 'Arkansas', population: 2915958, capital: 'Little Rock', region: 'South' },
+  { name: 'California', population: 37254503, capital: 'Sacramento', region: 'West' },
+  { name: 'Colorado', population: 5029324, capital: 'Denver', region: 'West' },
+  { name: 'Connecticut', population: 3574118, capital: 'Hartford', region: 'Northeast' },
+  { name: 'Delaware', population: 897936, capital: 'Dover', region: 'South' },
+  { name: 'Florida', population: 18804623, capital: 'Tallahassee', region: 'South' },
+  { name: 'Georgia', population: 9688681, capital: 'Atlanta', region: 'South' },
+  { name: 'Hawaii', population: 1360301, capital: 'Honolulu', region: 'West' },
+  { name: 'Idaho', population: 1567652, capital: 'Boise', region: 'West' },
+  { name: 'Illinois', population: 12831549, capital: 'Springfield', region: 'Midwest' },
+  { name: 'Indiana', population: 6484229, capital: 'Indianapolis', region: 'Midwest' },
+  { name: 'Iowa', population: 3046869, capital: 'Des Moines', region: 'Midwest' },
+  { name: 'Kansas', population: 2853132, capital: 'Topeka', region: 'Midwest' },
+  { name: 'Kentucky', population: 4339349, capital: 'Frankfort', region: 'South' },
+  { name: 'Louisiana', population: 4533479, capital: 'Baton Rouge', region: 'South' },
+  { name: 'Maine', population: 1328361, capital: 'Augusta', region: 'Northeast' },
+  { name: 'Maryland', population: 5773785, capital: 'Annapolis', region: 'South' },
+  { name: 'Massachusetts', population: 6547817, capital: 'Boston', region: 'Northeast' },
+  { name: 'Michigan', population: 9884129, capital: 'Lansing', region: 'Midwest' },
+  { name: 'Minnesota', population: 5303925, capital: 'Saint Paul', region: 'Midwest' },
+  { name: 'Mississippi', population: 2968103, capital: 'Jackson', region: 'South' },
+  { name: 'Missouri', population: 5988927, capital: 'Jefferson City', region: 'Midwest' },
+  { name: 'Montana', population: 989417, capital: 'Alberta', region: 'West' },
+  { name: 'Nebraska', population: 1826341, capital: 'Lincoln', region: 'Midwest' },
+  { name: 'Nevada', population: 2700691, capital: 'Carson City', region: 'West' },
+  { name: 'New Hampshire', population: 1316466, capital: 'Concord', region: 'Northeast' },
+  { name: 'New Jersey', population: 8791936, capital: 'Trenton', region: 'Northeast' },
+  { name: 'New Mexico', population: 2059192, capital: 'Santa Fe', region: 'West' },
+  { name: 'New York', population: 19378087, capital: 'Albany', region: 'Northeast' },
+  { name: 'North Carolina', population: 9535692, capital: 'Raleigh', region: 'South' },
+  { name: 'North Dakota', population: 672591, capital: 'Bismarck', region: 'Midwest' },
+  { name: 'Ohio', population: 11536725, capital: 'Columbus', region: 'Midwest' },
+  { name: 'Oklahoma', population: 3751616, capital: 'Oklahoma City', region: 'South' },
+  { name: 'Oregon', population: 3831073, capital: 'Salem', region: 'West' },
+  { name: 'Pennsylvania', population: 12702887, capital: 'Harrisburg', region: 'Northeast' },
+  { name: 'Rhode Island', population: 1052931, capital: 'Providence', region: 'Northeast' },
+  { name: 'South Carolina', population: 4625401, capital: 'Columbia', region: 'South' },
+  { name: 'South Dakota', population: 814191, capital: 'Pierre', region: 'Midwest' },
+  { name: 'Tennessee', population: 6346275, capital: 'Nashville', region: 'South' },
+  { name: 'Texas', population: 25146105, capital: 'Austin', region: 'South' },
+  { name: 'Utah', population: 2763888, capital: 'Salt Lake City', region: 'West' },
+  { name: 'Vermont', population: 625745, capital: 'Montpelier', region: 'Northeast' },
+  { name: 'Virginia', population: 8001045, capital: 'Richmond', region: 'South' },
+  { name: 'Washington', population: 6724543, capital: 'Olympia', region: 'West' },
+  { name: 'West Virginia', population: 1853011, capital: 'Charleston', region: 'South' },
+  { name: 'Wisconsin', population: 5687289, capital: 'Madison', region: 'West' },
+  { name: 'Wyoming', population: 563767, capital: 'Cheyenne', region: 'West' },
+]
+
+class MyTypeAhead extends PureComponent {
+
+    constructor(props) {
+        super(props)
+        //var screenName = props["screen_name"] || "SENATEMAJLDR"
+        this.state = {}
+        this.handleSelection = this.handleSelection.bind(this)
+    }
+
+    handleSelection(selectedItems){
+
+        //event.preventDefault() // prevent page reload
+        //var screenName = document.getElementById("inputScreenName").value
+
+        var selectedItem = selectedItems[0]
+
+        var screenName = selectedItem["name"]
+
+        console.log("YOU SELECTED A SCREEN NAME!", screenName)
+
+        //ReactGA.event({
+        //    category: "User Chart Interaction",
+        //    action: "Input Screen Name",
+        //    value: screenName
+        //})
+
+        this.setState({screenName: screenName})
+
+    }
+
+    render() {
+        return (
+            <Form.Group>
+                <Form.Label>Change User:</Form.Label>
+                <Typeahead
+                    id="basic-typeahead-single"
+                    labelKey="name"
+                    onChange={this.handleSelection}
+                    options={exampleOptions}
+                    placeholder="SENATEMAJLDR"
+                    selected={[]}
+                />
+            </Form.Group>
+        )
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 export default class UserOpinionSection extends PureComponent {
 
@@ -74,34 +195,19 @@ export default class UserOpinionSection extends PureComponent {
                             </Form.Row>
                         </Form>
 
-                        {/*
+                        <MyTypeAhead/>
 
-                        <Form inline style={{marginBottom:10}}>
-                            <Form.Row className="align-items-center">
-                                <Col xs="auto">
-                                    <Form.Label htmlFor="inputScreenName">Change User:</Form.Label>
-                                </Col>
-                                <Col xs="auto">
-                                    <InputGroup.Prepend><InputGroup.Text>@</InputGroup.Text></InputGroup.Prepend>
-                                    <Form.Control className="mb-2" id="inputScreenName" placeholder="POLITICO"/>
-                                </Col>
-
-
-
-                                <Col xs="auto">
-                                    <Button type="submit" className="mb-2" variant="secondary">Submit</Button>
-                                </Col>
-                            </Form.Row>
-                        </Form>
-
-                        */}
 
                     </Card.Body>
                 </Card>
 
                 <Card>
                     <Card.Body>
+                        {/*
                         <UserOpinionDashboard key={screenName} screenName={screenName}/>
+                        */}
+
+                        {screenName}
                     </Card.Body>
                 </Card>
             </Container>

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -2,88 +2,19 @@
 import React, { PureComponent } from 'react'
 import Container from 'react-bootstrap/Container'
 //import Row from 'react-bootstrap/Row'
-import Col from 'react-bootstrap/Col'
+//import Col from 'react-bootstrap/Col'
 import Card from 'react-bootstrap/Card'
 //import Table from 'react-bootstrap/Table'
 import Form from 'react-bootstrap/Form'
 //import FormControl from 'react-bootstrap/FormControl'
 //import InputGroup from 'react-bootstrap/InputGroup'
-import Button from 'react-bootstrap/Button'
+//import Button from 'react-bootstrap/Button'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import queryString from 'query-string'
 import ReactGA from 'react-ga'
 
 import UserOpinionDashboard from "./Dashboard"
-
 import users from "../TopUsers/data.js"
-
-//const exampleOptions = [
-//  { name: 'Alabama', population: 4780127, capital: 'Montgomery', region: 'South' },
-//  { name: 'Alaska', population: 710249, capital: 'Juneau', region: 'West' },
-//  { name: 'Arizona', population: 6392307, capital: 'Phoenix', region: 'West' },
-//]
-
-class MyTypeAhead extends PureComponent {
-
-    constructor(props) {
-        super(props)
-        var screenName = props["screen_name"]  || "Texas" //|| "SENATEMAJLDR"
-        this.state = {screenName: screenName}
-        this.handleSelection = this.handleSelection.bind(this)
-    }
-
-    handleSelection(selectedUsers){
-        //event.preventDefault() // prevent page reload
-        //var screenName = document.getElementById("inputScreenName").value
-
-        var screenName
-        var selectedUser = selectedUsers[0]
-        if(selectedUser){
-            screenName = selectedUser["screen_name"]
-            console.log("YOU SELECTED A SCREEN NAME!", screenName)
-            //ReactGA.event({
-            //    category: "User Chart Interaction",
-            //    action: "Input Screen Name",
-            //    value: screenName
-            //})
-        } else {
-            screenName = "" // prevent backspace key from doing funky things
-        }
-
-        this.setState({screenName: screenName})
-    }
-
-    render() {
-        return (
-            <Form.Group>
-                <Form.Label>Change User:</Form.Label>
-                <Typeahead
-                    id="top-users-typeahead"
-                    labelKey="screen_name"
-                    onChange={this.handleSelection}
-                    options={users}
-                    placeholder="SENATEMAJLDR"
-                    //selected={[this.state.screenName]}
-                />
-            </Form.Group>
-        )
-    }
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 export default class UserOpinionSection extends PureComponent {
@@ -93,18 +24,36 @@ export default class UserOpinionSection extends PureComponent {
         let params = queryString.parse(window.location.search)
         var screenName = props["screen_name"] || params["sn"] || "SENATEMAJLDR" // append ?sn=BERNIESANDERS to the URL to customize via URL params!!!
         this.state = {screenName: screenName}
-        this.handleSubmit = this.handleSubmit.bind(this)
+        //this.handleSubmit = this.handleSubmit.bind(this)
+        this.handleSelection = this.handleSelection.bind(this)
     }
 
-    handleSubmit(event){
-        event.preventDefault() // prevent page reload
-        var screenName = document.getElementById("inputScreenName").value
-        console.log("YOU CLICKED ME!", screenName)
-        ReactGA.event({
-            category: "User Chart Interaction",
-            action: "Input Screen Name",
-            value: screenName
-        })
+    //handleSubmit(event){
+    //    event.preventDefault() // prevent page reload
+    //    var screenName = document.getElementById("inputScreenName").value
+    //    console.log("YOU CLICKED ME!", screenName)
+    //    ReactGA.event({
+    //        category: "User Chart Interaction",
+    //        action: "Submit Screen Name",
+    //        label: screenName
+    //    })
+    //    this.setState({screenName: screenName})
+    //}
+
+    handleSelection(selectedUsers){
+        var selectedUser = selectedUsers[0]
+        var screenName
+        if(selectedUser){
+            screenName = selectedUser["screen_name"]
+            console.log("YOU SELECTED A SCREEN NAME!", screenName)
+            ReactGA.event({
+                category: "User Chart Interaction",
+                action: "Select Screen Name",
+                label: screenName
+            })
+        } else {
+            screenName = "" // prevent backspace key from doing funky things
+        }
         this.setState({screenName: screenName})
     }
 
@@ -121,13 +70,13 @@ export default class UserOpinionSection extends PureComponent {
                             {" "} on the language patterns of the anti-Trump and pro-Trump bot retweet communities,
                             {" "} we used the models to predict Impeachment opinion scores for the remaining tweets in our dataset.
                             {" "}We then calculated the mean Impeachment opinion score for all users in our dataset.
-                        </Card.Text>
 
-                        <Card.Text>
-                            The dashboard below shows how our models scored the tweets of any given user (e.g. <i>REALDONALDTRUMP</i>, <i>SPEAKERPELOSI</i>, <i>SENATEMAJLDR</i>, <i>NYTIMES</i>, <i>WSJ</i>, etc.).
+
+                            {" "} The dashboard below shows Impeachment opinion scores for any given user.
                             {" "} NOTE: tweets by <i>FOXNEWS</i> contain only URLs, and are not scored.
                         </Card.Text>
 
+                        {/*
                         <Form style={{marginBottom:10}}>
                             <Form.Row>
                                 <Form.Label>Change User:</Form.Label>
@@ -145,9 +94,19 @@ export default class UserOpinionSection extends PureComponent {
 
                             </Form.Row>
                         </Form>
+                        */}
 
-                        <MyTypeAhead/>
-
+                        <Form.Group>
+                            <Form.Label>Change User:</Form.Label>
+                            <Typeahead
+                                id="top-users-typeahead"
+                                labelKey="screen_name"
+                                onChange={this.handleSelection}
+                                options={users}
+                                placeholder="SENATEMAJLDR"
+                                //selected={[this.state.screenName]}
+                            />
+                        </Form.Group>
 
                     </Card.Body>
                 </Card>
@@ -155,10 +114,14 @@ export default class UserOpinionSection extends PureComponent {
                 <Card>
                     <Card.Body>
                         {/*
-                        <UserOpinionDashboard key={screenName} screenName={screenName}/>
-                        */}
 
                         {screenName}
+
+                        */}
+
+                        <UserOpinionDashboard key={screenName} screenName={screenName}/>
+
+
                     </Card.Body>
                 </Card>
             </Container>

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react'
 import Container from 'react-bootstrap/Container'
 //import Row from 'react-bootstrap/Row'
-//import Col from 'react-bootstrap/Col'
+import Col from 'react-bootstrap/Col'
 import Card from 'react-bootstrap/Card'
 //import Table from 'react-bootstrap/Table'
 import Form from 'react-bootstrap/Form'
@@ -95,8 +95,9 @@ export default class UserOpinionSection extends PureComponent {
                         </Form>
                         */}
 
+                        {/*
                         <Form.Group>
-                            <Form.Label>Change User (listed in order by follower count):</Form.Label>
+                            <Form.Label>Change User (listed by follower count):</Form.Label>
                             <Typeahead
                                 id="top-users-typeahead"
                                 onChange={this.handleSelection}
@@ -108,6 +109,31 @@ export default class UserOpinionSection extends PureComponent {
                                 //labelKey={(option) => `${option.screen_name} (${bigNumberLabel(option.follower_count)} active followers, ${option.status_count} tweets)`}
                             />
                         </Form.Group>
+
+
+                        */}
+                        <Form>
+                            <Form.Row>
+                                <Col xs="auto">
+                                    <Form.Label>Change User (listed by follower count):</Form.Label>
+
+                                    <Typeahead
+                                        id="top-users-typeahead"
+                                        onChange={this.handleSelection}
+                                        options={users}
+                                        placeholder="SENATEMAJLDR"
+                                        //selected={[this.state.screenName]}
+                                        labelKey="screen_name"
+                                        //labelKey={(option) => `${option.screen_name} (${bigNumberLabel(option.follower_count)} active followers)`}
+                                        //labelKey={(option) => `${option.screen_name} (${bigNumberLabel(option.follower_count)} active followers, ${option.status_count} tweets)`}
+                                    />
+                                </Col>
+
+
+
+                            </Form.Row>
+                        </Form>
+
 
                     </Card.Body>
                 </Card>

--- a/src/_App/OpinionAnalysis/User/Section.js
+++ b/src/_App/OpinionAnalysis/User/Section.js
@@ -15,91 +15,42 @@ import ReactGA from 'react-ga'
 
 import UserOpinionDashboard from "./Dashboard"
 
+import users from "../TopUsers/data.js"
 
-
-
-
-const exampleOptions = [
-  { name: 'Alabama', population: 4780127, capital: 'Montgomery', region: 'South' },
-  { name: 'Alaska', population: 710249, capital: 'Juneau', region: 'West' },
-  { name: 'Arizona', population: 6392307, capital: 'Phoenix', region: 'West' },
-  { name: 'Arkansas', population: 2915958, capital: 'Little Rock', region: 'South' },
-  { name: 'California', population: 37254503, capital: 'Sacramento', region: 'West' },
-  { name: 'Colorado', population: 5029324, capital: 'Denver', region: 'West' },
-  { name: 'Connecticut', population: 3574118, capital: 'Hartford', region: 'Northeast' },
-  { name: 'Delaware', population: 897936, capital: 'Dover', region: 'South' },
-  { name: 'Florida', population: 18804623, capital: 'Tallahassee', region: 'South' },
-  { name: 'Georgia', population: 9688681, capital: 'Atlanta', region: 'South' },
-  { name: 'Hawaii', population: 1360301, capital: 'Honolulu', region: 'West' },
-  { name: 'Idaho', population: 1567652, capital: 'Boise', region: 'West' },
-  { name: 'Illinois', population: 12831549, capital: 'Springfield', region: 'Midwest' },
-  { name: 'Indiana', population: 6484229, capital: 'Indianapolis', region: 'Midwest' },
-  { name: 'Iowa', population: 3046869, capital: 'Des Moines', region: 'Midwest' },
-  { name: 'Kansas', population: 2853132, capital: 'Topeka', region: 'Midwest' },
-  { name: 'Kentucky', population: 4339349, capital: 'Frankfort', region: 'South' },
-  { name: 'Louisiana', population: 4533479, capital: 'Baton Rouge', region: 'South' },
-  { name: 'Maine', population: 1328361, capital: 'Augusta', region: 'Northeast' },
-  { name: 'Maryland', population: 5773785, capital: 'Annapolis', region: 'South' },
-  { name: 'Massachusetts', population: 6547817, capital: 'Boston', region: 'Northeast' },
-  { name: 'Michigan', population: 9884129, capital: 'Lansing', region: 'Midwest' },
-  { name: 'Minnesota', population: 5303925, capital: 'Saint Paul', region: 'Midwest' },
-  { name: 'Mississippi', population: 2968103, capital: 'Jackson', region: 'South' },
-  { name: 'Missouri', population: 5988927, capital: 'Jefferson City', region: 'Midwest' },
-  { name: 'Montana', population: 989417, capital: 'Alberta', region: 'West' },
-  { name: 'Nebraska', population: 1826341, capital: 'Lincoln', region: 'Midwest' },
-  { name: 'Nevada', population: 2700691, capital: 'Carson City', region: 'West' },
-  { name: 'New Hampshire', population: 1316466, capital: 'Concord', region: 'Northeast' },
-  { name: 'New Jersey', population: 8791936, capital: 'Trenton', region: 'Northeast' },
-  { name: 'New Mexico', population: 2059192, capital: 'Santa Fe', region: 'West' },
-  { name: 'New York', population: 19378087, capital: 'Albany', region: 'Northeast' },
-  { name: 'North Carolina', population: 9535692, capital: 'Raleigh', region: 'South' },
-  { name: 'North Dakota', population: 672591, capital: 'Bismarck', region: 'Midwest' },
-  { name: 'Ohio', population: 11536725, capital: 'Columbus', region: 'Midwest' },
-  { name: 'Oklahoma', population: 3751616, capital: 'Oklahoma City', region: 'South' },
-  { name: 'Oregon', population: 3831073, capital: 'Salem', region: 'West' },
-  { name: 'Pennsylvania', population: 12702887, capital: 'Harrisburg', region: 'Northeast' },
-  { name: 'Rhode Island', population: 1052931, capital: 'Providence', region: 'Northeast' },
-  { name: 'South Carolina', population: 4625401, capital: 'Columbia', region: 'South' },
-  { name: 'South Dakota', population: 814191, capital: 'Pierre', region: 'Midwest' },
-  { name: 'Tennessee', population: 6346275, capital: 'Nashville', region: 'South' },
-  { name: 'Texas', population: 25146105, capital: 'Austin', region: 'South' },
-  { name: 'Utah', population: 2763888, capital: 'Salt Lake City', region: 'West' },
-  { name: 'Vermont', population: 625745, capital: 'Montpelier', region: 'Northeast' },
-  { name: 'Virginia', population: 8001045, capital: 'Richmond', region: 'South' },
-  { name: 'Washington', population: 6724543, capital: 'Olympia', region: 'West' },
-  { name: 'West Virginia', population: 1853011, capital: 'Charleston', region: 'South' },
-  { name: 'Wisconsin', population: 5687289, capital: 'Madison', region: 'West' },
-  { name: 'Wyoming', population: 563767, capital: 'Cheyenne', region: 'West' },
-]
+//const exampleOptions = [
+//  { name: 'Alabama', population: 4780127, capital: 'Montgomery', region: 'South' },
+//  { name: 'Alaska', population: 710249, capital: 'Juneau', region: 'West' },
+//  { name: 'Arizona', population: 6392307, capital: 'Phoenix', region: 'West' },
+//]
 
 class MyTypeAhead extends PureComponent {
 
     constructor(props) {
         super(props)
-        //var screenName = props["screen_name"] || "SENATEMAJLDR"
-        this.state = {}
+        var screenName = props["screen_name"]  || "Texas" //|| "SENATEMAJLDR"
+        this.state = {screenName: screenName}
         this.handleSelection = this.handleSelection.bind(this)
     }
 
-    handleSelection(selectedItems){
-
+    handleSelection(selectedUsers){
         //event.preventDefault() // prevent page reload
         //var screenName = document.getElementById("inputScreenName").value
 
-        var selectedItem = selectedItems[0]
-
-        var screenName = selectedItem["name"]
-
-        console.log("YOU SELECTED A SCREEN NAME!", screenName)
-
-        //ReactGA.event({
-        //    category: "User Chart Interaction",
-        //    action: "Input Screen Name",
-        //    value: screenName
-        //})
+        var screenName
+        var selectedUser = selectedUsers[0]
+        if(selectedUser){
+            screenName = selectedUser["screen_name"]
+            console.log("YOU SELECTED A SCREEN NAME!", screenName)
+            //ReactGA.event({
+            //    category: "User Chart Interaction",
+            //    action: "Input Screen Name",
+            //    value: screenName
+            //})
+        } else {
+            screenName = "" // prevent backspace key from doing funky things
+        }
 
         this.setState({screenName: screenName})
-
     }
 
     render() {
@@ -107,12 +58,12 @@ class MyTypeAhead extends PureComponent {
             <Form.Group>
                 <Form.Label>Change User:</Form.Label>
                 <Typeahead
-                    id="basic-typeahead-single"
-                    labelKey="name"
+                    id="top-users-typeahead"
+                    labelKey="screen_name"
                     onChange={this.handleSelection}
-                    options={exampleOptions}
+                    options={users}
                     placeholder="SENATEMAJLDR"
-                    selected={[]}
+                    //selected={[this.state.screenName]}
                 />
             </Form.Group>
         )


### PR DESCRIPTION
  + Improves content across the site
  + Adds axis formatting to more charts
  + Force Graphs: fixes dynamic layout concerns, but still running into issues of scale (we need smaller networks to display or else it takes too long to load the data) 
  + Daily Activity Chart: enables customization of which metrics are selectable (no metrics hides the form altogether)
  + Updates language from "bot retweet networks to "bot retweet communities"
  + Splits bot opinions chart to its own page
  + Top User Opinions Chart:
    + removes tooltips from top users chart controls, to improve layout on mobile devices
    + resets chart defaults, to encourage more interaction with chart controls
  + User Opinion Dashboard: changes normal button submit to a typeahead selection pre-filled with screen names of top users